### PR TITLE
fix: remove msg encoding in encodeCSMessageResponse

### DIFF
--- a/contracts/evm/xcall/contracts/libraries/RLPEncodeStruct.sol
+++ b/contracts/evm/xcall/contracts/libraries/RLPEncodeStruct.sol
@@ -54,8 +54,7 @@ library RLPEncodeStruct {
         bytes memory _rlp =
             abi.encodePacked(
                 _bs.sn.encodeUint(),
-                _bs.code.encodeInt(),
-                _bs.msg.encodeString()
+                _bs.code.encodeInt()
             );
         return _rlp.encodeList();
     }


### PR DESCRIPTION
## Description:

### Commit Message

```bash
Remove unwanted msg.encode on encode CSMessageResponse
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
