### PR TITLE
fix: add default connection setter

### DIFF
--- a/contracts/evm/xcall/contracts/CallService.sol
+++ b/contracts/evm/xcall/contracts/CallService.sol
@@ -447,6 +447,10 @@ contract CallService is IBSH, ICallService, IFeeManage, Initializable {
         return feeHandler;
     }
 
+    function setDefaultConnection(string memory nid, address connection) external onlyAdmin {
+        defaultConnections[nid] = connection;
+    }
+
     function setProtocolFee(
         uint256 _value
     ) external override onlyAdmin {

--- a/contracts/evm/xcall/contracts/CallService.sol
+++ b/contracts/evm/xcall/contracts/CallService.sol
@@ -347,9 +347,9 @@ contract CallService is IBSH, ICallService, IFeeManage, Initializable {
                 delete pendingReqs[dataHash][req.protocols[i]];
             }
         } else if (req.protocols.length == 1) {
-            require(msg.sender == req.protocols[0].parseAddress("IllegalArgument"));
+            require(msg.sender == req.protocols[0].parseAddress("IllegalArgument"), "NotAuthorized");
         } else {
-            require(msg.sender == defaultConnections[fromNID]);
+            require(msg.sender == defaultConnections[fromNID], "NotAuthorized");
         }
 
         uint256 reqId = getNextReqId();
@@ -385,9 +385,9 @@ contract CallService is IBSH, ICallService, IFeeManage, Initializable {
                 delete pendingResponses[res.sn][req.sources[i]];
             }
         } else if (req.sources.length == 1) {
-            require(msg.sender == req.sources[0].parseAddress("IllegalArgument"));
+            require(msg.sender == req.sources[0].parseAddress("IllegalArgument"), "NotAuthorized");
         } else {
-            require(msg.sender == defaultConnections[req.to]);
+            require(msg.sender == defaultConnections[req.to], "NotAuthorized");
         }
 
         emit ResponseMessage(res.sn, res.code);

--- a/contracts/evm/xcall/contracts/CallService.sol
+++ b/contracts/evm/xcall/contracts/CallService.sol
@@ -76,7 +76,7 @@ contract CallService is IBSH, ICallService, IFeeManage, Initializable {
         return networkAddress;
     }
 
-     function getNetworkId(
+    function getNetworkId(
     ) external view override returns (
         string memory
     ) {
@@ -138,6 +138,7 @@ contract CallService is IBSH, ICallService, IFeeManage, Initializable {
 
         if (sources.length == 0) {
             address conn = defaultConnections[netTo];
+            require(conn != address(0), "NoDefaultConnection");
             uint256 requiredFee = IConnection(conn).getFee(netTo, needResponse);
             sendBTPMessage(conn, requiredFee, netTo, Types.CS_REQUEST, msgSn, _msg);
         } else {


### PR DESCRIPTION
## Description:

- Add setDefaultConnection() with adminGuard
- Add revertMessages on `require()`

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
