### PR TITLE
fix: Prevent networkId to be from native chain when receiving call messsages.

### DIFF
--- a/contracts/cosmwasm-vm/cw-xcall/src/handle_call_message.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/src/handle_call_message.rs
@@ -11,12 +11,12 @@ impl<'a> CwCallService<'a> {
         from_nid: NetId,
         message: Vec<u8>,
     ) -> Result<Response, ContractError> {
-        let call_service_message: CSMessage = CSMessage::try_from(message)?;
         let cfg = self.get_config(deps.storage).unwrap();
         if cfg.network_id == from_nid.to_string() {
             return Err(ContractError::ProtocolsMismatch);
         }
 
+        let call_service_message: CSMessage = CSMessage::try_from(message)?;
         match call_service_message.message_type() {
             CallServiceMessageType::CallServiceRequest => {
                 self.handle_request(deps, info, from_nid, call_service_message.payload())

--- a/contracts/cosmwasm-vm/cw-xcall/tests/test_request.rs
+++ b/contracts/cosmwasm-vm/cw-xcall/tests/test_request.rs
@@ -4,7 +4,7 @@ mod setup;
 use std::str::FromStr;
 
 use cosmwasm_std::testing::mock_env;
-use cw_xcall::state::CwCallService;
+use cw_xcall::{error::ContractError, state::CwCallService};
 use cw_xcall_lib::network_address::NetId;
 use setup::test::*;
 
@@ -159,7 +159,6 @@ fn set_request_id_without_proper_initialisation() {
         .unwrap();
 }
 
-
 #[test]
 fn invalid_network_id() {
     let mut mock_deps = deps();
@@ -181,10 +180,17 @@ fn invalid_network_id() {
         )
         .unwrap();
 
-
-    let response = contract
-        .handle_message(mock_deps.as_mut(), mock_info, NetId::from_str("nid").unwrap(), vec![]);
+    let response = contract.handle_message(
+        mock_deps.as_mut(),
+        mock_info,
+        NetId::from_str("nid").unwrap(),
+        vec![],
+    );
 
     assert!(response.is_err());
+    let error = response.err().unwrap();
+    assert_eq!(
+        error.to_string(),
+        ContractError::ProtocolsMismatch.to_string()
+    );
 }
-


### PR DESCRIPTION


## Description:

### Commit Message

```bash
type: commit message
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [x] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have run the unit tests
- [x] I only have one commit (if not, squash them into one commit).
- [x] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
