### PR TITLE
fix: remove duplicate store connection message sequence

### DIFF
--- a/contracts/cosmwasm-vm/cw-centralized-connection/src/contract.rs
+++ b/contracts/cosmwasm-vm/cw-centralized-connection/src/contract.rs
@@ -43,7 +43,6 @@ impl<'a> CwCentralizedConnection<'a> {
         self.ensure_xcall(deps.storage, info.sender)?;
 
         let next_conn_sn = self.get_next_conn_sn(deps.storage)?;
-        self.store_conn_sn(deps.storage, next_conn_sn)?;
 
         let mut fee = 0;
 


### PR DESCRIPTION
changes made
- fixed storing same connection sequence for two times when sending message