### PR TITLE
fix: message field added in rollback event

### DIFF
--- a/contracts/sui/xcall/sources/main.move
+++ b/contracts/sui/xcall/sources/main.move
@@ -76,7 +76,8 @@ module xcall::main {
 
     public struct RollbackMessage has copy, drop{
         sn:u128,
-        dapp: String
+        dapp: String,
+        data:vector<u8>,
     }
 
     public struct RollbackExecuted has copy, drop{
@@ -391,7 +392,7 @@ module xcall::main {
         let mut_rollback = xcall_state::get_mut_rollback(self, sequence_no);
         rollback_data::enable_rollback(mut_rollback);
         //std::debug::print(&rollback_data::enabled(mut_rollback));
-        event::emit(RollbackMessage{sn:sequence_no, dapp: utils::id_to_hex_string(&rollback_data::from(&rollback)) });
+        event::emit(RollbackMessage{sn:sequence_no, dapp: utils::id_to_hex_string(&rollback_data::from(&rollback)), data: rollback.rollback() });
     };
     }
 


### PR DESCRIPTION
## Description:

### Commit Message

```bash
fix: message field added in rollback event
```

see the [guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages) for commit messages.

### Changelog Entry

```bash
version: <log entry>
```

## Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have documented my code in accordance with the [documentation guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#documentation)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have run the unit tests
- [ ] I only have one commit (if not, squash them into one commit).
- [ ] I have a descriptive commit message that adheres to the [commit message guidelines](https://github.com/icon-project/community/blob/main/guidelines/technical/software-development-guidelines.md#commit-messages)

> Please review the [CONTRIBUTING.md](/CONTRIBUTING.md) file for detailed contributing guidelines.
